### PR TITLE
Remove definition of BOOST_FIBERS_USE_VARIADIC_FIBER

### DIFF
--- a/include/boost/fiber/detail/config.hpp
+++ b/include/boost/fiber/detail/config.hpp
@@ -42,14 +42,4 @@
 # define BOOST_FIBERS_SEGMENTS 10
 #endif
 
-#if ! defined(BOOST_NO_SFINAE_EXPR) && \
-    ! defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && \
-    ! defined(BOOST_NO_CXX11_DECLTYPE) && \
-    ! defined(BOOST_NO_CXX11_DECLTYPE_N3276) && \
-    ! defined(BOOST_NO_CXX11_AUTO) && \
-    ! defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
-    ! defined(BOOST_NO_CXX11_HDR_TUPLE)
-# define BOOST_FIBERS_USE_VARIADIC_FIBER
-#endif
-
 #endif // BOOST_FIBERS_DETAIL_CONFIG_H


### PR DESCRIPTION
Since the usage of variadic templates is now enabled by default and not emulated, the definition of the `BOOST_FIBERS_USE_VARIADIC_FIBER` macro can be removed.