### PR TITLE
test_try_push() fix and channel::is_closed() wording

### DIFF
--- a/doc/channel.qbk
+++ b/doc/channel.qbk
@@ -110,7 +110,9 @@ channel operations return the state of the channel.
 [variablelist
 [[Returns:] [`true` if channel has been closed.]]
 [[Throws:] [Nothing.]]
-[[Note:] [The channel is not closed by default.]]
+[[Note:] [The channel is not closed by default. `is_closed()` returns `true`
+when `close()` has been called, whether or not there are pending values in the
+channel. The channel is not exhausted until `is_closed() && is_empty()`.]]
 ]
 ]
 [xchannel_is_closed unbounded_channel]

--- a/test/test_bounded_channel.cpp
+++ b/test/test_bounded_channel.cpp
@@ -101,7 +101,7 @@ void test_try_push()
 {
     boost::fibers::bounded_channel< int > c( 1);
     BOOST_CHECK( c.is_empty() );
-    BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( 1) );
+    BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( 1) );
     BOOST_CHECK( ! c.is_empty() );
 }
 


### PR DESCRIPTION
I realize channel::is_closed() is likely to vanish soon, but until it does, we should describe its effects properly to avoid confusion.

test_try_push() should call try_push() rather than push().