### PR TITLE
Eliminate opaque fiber_properties::back_ptr typedef.

### DIFF
--- a/examples/priority.cpp
+++ b/examples/priority.cpp
@@ -11,7 +11,7 @@
 class priority_props: public boost::fibers::fiber_properties
 {
 public:
-    priority_props(boost::fibers::fiber_properties::back_ptr p):
+    priority_props(boost::fibers::fiber_context* p):
         fiber_properties(p),
         priority_(0)
     {}

--- a/include/boost/fiber/properties.hpp
+++ b/include/boost/fiber/properties.hpp
@@ -40,13 +40,12 @@ protected:
     void notify();
 
 public:
-    // fiber_properties, and by implication every subclass, must accept a back
-    // pointer to its fiber_context.
-    typedef fiber_context   *   back_ptr;
-
     // Any specific property setter method, after updating the relevant
     // instance variable, can/should call notify().
-    fiber_properties( back_ptr f):
+
+    // fiber_properties, and by implication every subclass, must accept a back
+    // pointer to its fiber_context.
+    fiber_properties( fiber_context* f):
         fiber_( f),
         sched_algo_( nullptr)
     {}


### PR DESCRIPTION
It's more straightforward to use the underlying type: fiber_context*.