### PR TITLE
Add tests for bounded_channel::lower_bound().

### DIFF
--- a/doc/channel.qbk
+++ b/doc/channel.qbk
@@ -266,16 +266,15 @@ time as (system time + `timeout_duration`).
         bounded_channel( std::size_t hwm, std::size_t lwm);
 
 [variablelist
-[[Preconditions:] [`hwm >= lwm`]]
+[[Preconditions:] [`hwm > lwm`]]
 [[Effects:] [Constructs an object of class `bounded_channel`. The constructor
 with two arguments constructs an object of class `bounded_channel` with a
 high-watermark of `hwm` and a low-watermark of `lwm` items. The constructor
-with one argument effectively sets both `hwm` and `lwm` to the same value
-`wm`.]]
-[[Throws:] [`invalid_argument` if `lwm > hwm`.]]
+with one argument is effectively the same as `bounded_channel(wm, (wm-1))`.]]
+[[Throws:] [`invalid_argument` if `lwm >= hwm`.]]
 [[Notes:] [Once the number of values in the channel reaches `hwm`, any call to
 `push()`, `push_wait_for()` or `push_wait_until()` will block until the number
-of values in the channel has dropped below `lwm`. That is, if `lwm < hwm`, the
+of values in the channel is at most `lwm`. That is, if `lwm < (hwm-1)`, the
 channel can be in a state in which `push()`, `push_wait_for()` or `push_wait_until()`
 calls will block (channel is full) even though the number of values
 in the channel is less than `hwm`.]]
@@ -303,7 +302,7 @@ in the channel is less than `hwm`.]]
 
 [template bounded_channel_push_effects[or] [xchannel_push_effects If channel
 is not full, enqueues] Otherwise the calling fiber is suspended until
-the number of values in the channel drops below `lwm` (return value
+the number of values in the channel drops to `lwm` (return value
 `success`)[or] the channel is `close()`d (return value `closed`)]
 
 [member_heading bounded_channel..push]
@@ -361,7 +360,7 @@ time_point (return value `timeout`).]]
 ]
 
 [template bounded_pop_unblocking[] Once the number of items remaining in the
-channel drops below `lwm`, any fibers blocked on `push()`, `push_wait_for()`
+channel drops to `lwm`, any fibers blocked on `push()`, `push_wait_for()`
 or `push_wait_until()` may resume.]
 
 [xchannel_pop bounded_channel... [bounded_pop_unblocking]]

--- a/test/test_bounded_channel.cpp
+++ b/test/test_bounded_channel.cpp
@@ -83,6 +83,8 @@ void test_hwm_less_lwm()
 void test_push()
 {
     boost::fibers::bounded_channel< int > c( 10);
+    BOOST_CHECK_EQUAL( c.upper_bound(), 10u );
+    BOOST_CHECK_EQUAL( c.lower_bound(), 9u );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( 1) );
 }
 
@@ -110,6 +112,7 @@ void test_try_push_closed()
 void test_try_push_full()
 {
     boost::fibers::bounded_channel< int > c( 1);
+    BOOST_CHECK_EQUAL( c.lower_bound(), 0u );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( 1) );
     BOOST_CHECK( boost::fibers::channel_op_status::full == c.try_push( 2) );
 }
@@ -390,23 +393,23 @@ void test_wm_1()
     });
     boost::fibers::fiber f2([&c,&ids](){
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 1 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 1, c.value_pop() );
 
         // let other fiber run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 2 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 2, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 3 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 3, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 4 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 4, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
         // would block because channel is empty
-        BOOST_CHECK( 5 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 5, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
     });
@@ -414,7 +417,7 @@ void test_wm_1()
     boost::fibers::fiber::id id2 = f2.get_id();
     f1.join();
     f2.join();
-    BOOST_CHECK( 12 == ids.size() );
+    BOOST_CHECK_EQUAL( 12u, ids.size() );
     BOOST_CHECK_EQUAL( id1, ids[0]); // f1 pushes 1
     BOOST_CHECK_EQUAL( id1, ids[1]); // f1 pushes 2
     BOOST_CHECK_EQUAL( id1, ids[2]); // f1 pushes 3
@@ -455,25 +458,25 @@ void test_wm_2()
     });
     boost::fibers::fiber f2([&c,&ids](){
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 1 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 1, c.value_pop() );
 
         // let other fiber run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 2 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 2, c.value_pop() );
 
         // let other fiber run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 3 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 3, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 4 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 4, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 5 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 5, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
     });
@@ -481,7 +484,7 @@ void test_wm_2()
     boost::fibers::fiber::id id2 = f2.get_id();
     f1.join();
     f2.join();
-    BOOST_CHECK( 12 == ids.size() );
+    BOOST_CHECK_EQUAL( 12u, ids.size() );
     BOOST_CHECK_EQUAL( id1, ids[0]); // f1 pushes 1
     BOOST_CHECK_EQUAL( id1, ids[1]); // f1 pushes 2
     BOOST_CHECK_EQUAL( id1, ids[2]); // f1 pushes 3
@@ -499,6 +502,8 @@ void test_wm_2()
 void test_wm_3()
 {
     boost::fibers::bounded_channel< int > c( 3, 1);
+    BOOST_CHECK_EQUAL( c.upper_bound(), 3u );
+    BOOST_CHECK_EQUAL( c.lower_bound(), 1u );
     std::vector< boost::fibers::fiber::id > ids;
     boost::fibers::fiber f1([&c,&ids](){
         ids.push_back( boost::this_fiber::get_id() );
@@ -521,25 +526,25 @@ void test_wm_3()
     });
     boost::fibers::fiber f2([&c,&ids](){
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 1 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 1, c.value_pop() );
 
         // let other fiber run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 2 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 2, c.value_pop() );
 
         // let other fiber run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 3 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 3, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 4 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 4, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 5 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 5, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
     });
@@ -547,7 +552,7 @@ void test_wm_3()
     boost::fibers::fiber::id id2 = f2.get_id();
     f1.join();
     f2.join();
-    BOOST_CHECK( 12 == ids.size() );
+    BOOST_CHECK_EQUAL( 12u, ids.size() );
     BOOST_CHECK_EQUAL( id1, ids[0]); // f1 pushes 1
     BOOST_CHECK_EQUAL( id1, ids[1]); // f1 pushes 2
     BOOST_CHECK_EQUAL( id1, ids[2]); // f1 pushes 3
@@ -584,26 +589,26 @@ void test_wm_4()
     });
     boost::fibers::fiber f2([&c,&ids](){
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 1 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 1, c.value_pop() );
 
         // let potential other fibers run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 2 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 2, c.value_pop() );
 
         // let potential other fibers run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
-        BOOST_CHECK( 3 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 3, c.value_pop() );
 
         // let potential other fibers run
         boost::this_fiber::yield();
 
         ids.push_back( boost::this_fiber::get_id() );
         // would block because channel is empty
-        BOOST_CHECK( 4 == c.value_pop() );
+        BOOST_CHECK_EQUAL( 4, c.value_pop() );
 
         ids.push_back( boost::this_fiber::get_id() );
     });
@@ -611,7 +616,7 @@ void test_wm_4()
     boost::fibers::fiber::id id2 = f2.get_id();
     f1.join();
     f2.join();
-    BOOST_CHECK( 10 == ids.size() );
+    BOOST_CHECK_EQUAL( 10u, ids.size() );
     BOOST_CHECK_EQUAL( id1, ids[0]); // f1 pushes 1
     BOOST_CHECK_EQUAL( id1, ids[1]); // f1 pushes 2
     BOOST_CHECK_EQUAL( id1, ids[2]); // f1 pushes 3

--- a/test/test_bounded_channel.cpp
+++ b/test/test_bounded_channel.cpp
@@ -80,6 +80,17 @@ void test_hwm_less_lwm()
     BOOST_CHECK( thrown);
 }
 
+void test_hwm_equal_lwm()
+{
+    bool thrown = false;
+    try {
+        boost::fibers::bounded_channel< int > c( 3, 3);
+    } catch ( boost::fibers::fiber_exception const&) {
+        thrown = true;
+    }
+    BOOST_CHECK( thrown);
+}
+
 void test_push()
 {
     boost::fibers::bounded_channel< int > c( 10);
@@ -655,6 +666,7 @@ boost::unit_test::test_suite * init_unit_test_suite( int, char* [])
      test->add( BOOST_TEST_CASE( & test_zero_wm_1) );
      test->add( BOOST_TEST_CASE( & test_zero_wm_2) );
      test->add( BOOST_TEST_CASE( & test_hwm_less_lwm) );
+     test->add( BOOST_TEST_CASE( & test_hwm_equal_lwm) );
      test->add( BOOST_TEST_CASE( & test_push) );
      test->add( BOOST_TEST_CASE( & test_push_closed) );
      test->add( BOOST_TEST_CASE( & test_try_push) );


### PR DESCRIPTION
We intend to document that bounded_channel(hwm) is equivalent to
bounded_channel(hwm, (hwm-1)). That may or may not simplify the code, but it
certainly simplifies the reader's mental model of the relationship between the
two constructors.

However, that assertion requires that for bounded_channel(hwm), lower_bound()
in fact return (hwm-1). Test for that.

Also use BOOST_CHECK_EQUAL(a, b) instead of BOOST_CHECK(a == b) where
applicable, since the former is more informative when the test fails.

Sadly, tests on channel_op_status must still use BOOST_CHECK(a == b) --
apparently because channel_op_status, as an enum class, cannot be streamed to
std::ostream?