### PR TITLE
Add callbacks.qbk about interfacing Fiber with async callbacks.

### DIFF
--- a/doc/callbacks.qbk
+++ b/doc/callbacks.qbk
@@ -1,0 +1,214 @@
+[/
+      Copyright Oliver Kowalke, Nat Goodspeed 2015.
+ Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at
+          http://www.boost.org/LICENSE_1_0.txt
+]
+
+[/ import path is relative to this .qbk file]
+[import ../examples/adapt_callbacks.cpp]
+[import ../examples/adapt_method_calls.cpp]
+
+[#callbacks]
+[section:callbacks Integrating Fibers with Asynchronous Callbacks]
+
+[heading Overview]
+
+One of the primary benefits of __boost_fiber__ is the ability to use
+asynchronous operations for efficiency, while at the same time structuring the
+calling code ['as if] the operations were synchronous. Asynchronous operations
+provide completion notification in a variety of ways, but most involve a
+callback function of some kind. This section discusses tactics for interfacing
+__boost_fiber__ with an arbitrary async operation.
+
+For purposes of illustration, consider the following hypothetical API:
+
+[AsyncAPI]
+
+The significant points about each of `init_write()` and `init_read()` are:
+
+* The `AsyncAPI` method only initiates the operation. It returns immediately,
+  while the requested operation is still pending.
+* The method accepts a callback. When the operation completes, the callback is
+  called with relevant parameters (error code, data if applicable).
+
+We would like to wrap these asynchronous methods in functions that appear
+synchronous by blocking the calling fiber until the operation completes. This
+lets us use the wrapper function's return value to deliver relevant data.
+
+[tip [template_link promise] and [template_link future] are your friends here.]
+
+[heading Return Errorcode]
+
+The `AsyncAPI::init_write()` callback passes only an `errorcode`. If we simply
+want the blocking wrapper to return that `errorcode`, this is an extremely
+straightforward use of [template_link promise] and [template_link future]:
+
+[callbacks_write_ec]
+
+All we have to do is:
+
+# Instantiate a `promise<>` of correct type.
+# Obtain its `future<>`.
+# Arrange for the callback to call [member_link promise..set_value].
+# Block on [member_link future..get].
+
+[note This tactic for resuming a pending fiber works even if the callback is
+called on a different thread than the one on which the initiating fiber is
+running. In fact, the example program's dummy `AsyncAPI` implementation
+illustrates that: it simulates async I/O by launching a new thread that sleeps
+briefly and then calls the relevant callback.]
+
+[heading Success or Exception]
+
+A wrapper more aligned with modern C++ practice would use an exception, rather
+than an `errorcode`, to communicate failure to its caller. This is
+straightforward to code in terms of `write_ec()`:
+
+[callbacks_write]
+
+The point is that since each fiber has its own stack, you need not repeat
+messy boilerplate: normal encapsulation works.
+
+[heading Return Errorcode or Data]
+
+Things get a bit more interesting when the async operation's callback passes
+multiple data items of interest. One approach would be to use `std::pair<>` to
+capture both:
+
+[callbacks_read_ec]
+
+Once you bundle the interesting data in `std::pair<>`, the code is effectively
+identical to `write_ec()`. You can call it like this:
+
+[callbacks_read_ec_call]
+
+[heading Data or Exception]
+
+But a more natural API for a function that obtains data is to return only the
+data on success, throwing an exception on error.
+
+As with `write()` above, it's certainly possible to code a `read()` wrapper in
+terms of `read_ec()`. But since a given application is unlikely to need both,
+let's code `read()` from scratch, leveraging [member_link
+promise..set_exception]:
+
+[callbacks_read]
+
+[member_link future..get] will do the right thing, either returning
+`std::string` or throwing an exception.
+
+[heading Success/Error Virtual Methods]
+
+One classic approach to completion notification is to define an abstract base
+class with `success()` and `error()` methods. Code wishing to perform async
+I/O must derive a subclass, override each of these methods and pass the async
+operation a pointer to a subclass instance. The abstract base class might look
+like this:
+
+[Response]
+
+Now the `AsyncAPI` operation might look more like this:
+
+[method_init_read]
+
+We can address this by writing a one-size-fits-all `PromiseResponse`:
+
+[PromiseResponse]
+
+Now we can simply obtain the `future<>` from that `PromiseResponse` and wait
+on its `get()`:
+
+[method_read]
+
+[/ @path link is relative to (eventual) doc/html/index.html, hence ../..]
+The source code above is found in
+[@../../examples/adapt_callbacks.cpp adapt_callbacks.cpp]
+and
+[@../../examples/adapt_method_calls.cpp adapt_method_calls.cpp].
+
+[heading Then There's __boost_asio__]
+
+[import ../examples/asio/yield.hpp]
+[import ../examples/asio/promise_completion_token.hpp]
+[import ../examples/asio/detail/yield.hpp]
+[import ../examples/asio/detail/promise_handler.hpp]
+
+Since the simplest form of Boost.Asio asynchronous operation completion token
+is a callback function, we could apply the same tactics for Asio as for our
+hypothetical `AsyncAPI` asynchronous operations.
+
+Fortunately we need not. Boost.Asio incorporates a mechanism by which the
+caller can customize the notification behavior of every async operation.
+Therefore we can construct a ['completion token] which, when passed to a
+__boost_asio__ async operation, requests blocking for the calling fiber. The
+underlying implementation uses the same mechanism as described above.
+
+`boost::fibers::asio::yield` is such a completion token. `yield` is an
+instance of `yield_t`:
+
+[fibers_asio_yield]
+
+which isa `promise_completion_token`:
+
+[fibers_asio_yield_t]
+
+`promise_completion_token` is common to both `yield` and `use_future`. (The
+interested reader is encouraged to learn more about `use_future` in
+[@../../examples/asio/use_future.hpp example source code].)
+
+`promise_completion_token` is in fact only a placeholder, a way to trigger
+Boost.Asio customization. It can bind a custom allocator or
+[@http://www.boost.org/doc/libs/release/libs/system/doc/reference.html#Class-error_code
+`boost::system::error_code`]
+for use by the actual handler.
+
+[fibers_asio_promise_completion_token]
+
+Asio customization is engaged by specializing
+[@http://www.boost.org/doc/libs/release/doc/html/boost_asio/reference/handler_type.html
+`boost::asio::handler_type<>`]
+for `yield_t`:
+
+[asio_handler_type]
+
+(There are actually four different specializations in
+[@../../examples/asio/detail/yield.hpp detail/yield.hpp],
+one for each of the four Asio async callback signatures we expect to have to
+support.)
+
+The above directs Asio to use `yield_handler` as the actual handler for an
+async operation to which `yield` is passed.
+
+`yield_handler` is simply an alias for `promise_handler`, because
+`promise_handler` is shared with the `use_future` machinery:
+
+[fibers_asio_yield_handler]
+
+`promise_handler` isa `promise_handler_base`:
+
+[fibers_asio_promise_handler_base]
+
+As promised, `promise_handler_base` binds a [template_link promise] of
+appropriate type. (We store a `shared_ptr<promise<T>>` because the
+`promise_handler` instance is copied on its way into underlying Asio
+machinery.)
+
+Asio, having consulted the `yield_handler` traits specialization, instantiates
+a `yield_handler` (aka `promise_handler`) as the async operation's callback:
+
+[fibers_asio_promise_handler]
+
+Like the lambda callback in our `read(AsyncAPI&)` presented earlier,
+`promise_handler::operator()()` either calls [member_link promise..set_value]
+or [member_link promise..set_exception] (via
+`promise_handler_base::should_set_value()`).
+
+[/ @path link is relative to (eventual) doc/html/index.html, hence ../..]
+The source code above is found in
+[@../../examples/asio/yield.hpp yield.hpp],
+[@../../examples/asio/promise_completion_token.hpp promise_completion_token.hpp],
+[@../../examples/asio/detail/yield.hpp detail/yield.hpp] and
+[@../../examples/asio/detail/promise_handler.hpp detail/promise_handler.hpp].
+
+[endsect]

--- a/doc/fibers.qbk
+++ b/doc/fibers.qbk
@@ -190,6 +190,7 @@ object are running in the same thread.
 [endsect]
 [include fls.qbk]
 [/[include asio.qbk]]
+[include callbacks.qbk]
 [include integration.qbk]
 [include performance.qbk]
 [include customization.qbk]

--- a/examples/adapt_callbacks.cpp
+++ b/examples/adapt_callbacks.cpp
@@ -15,6 +15,7 @@
 /*****************************************************************************
 *   example async API
 *****************************************************************************/
+//[AsyncAPI
 class AsyncAPI
 {
 public:
@@ -32,12 +33,15 @@ public:
     void init_read(const std::function<void(errorcode, const std::string&)>&);
 
     // ... other operations ...
+//<-
     void inject_error(errorcode ec);
 
 private:
     std::string data_;
     errorcode injected_;
+//->
 };
+//]
 
 /*****************************************************************************
 *   fake AsyncAPI implementation... pay no attention to the little man behind
@@ -94,6 +98,7 @@ void AsyncAPI::init_read(const std::function<void(errorcode, const std::string&)
 // helper function used in a couple of the adapters
 std::runtime_error make_exception(const std::string& desc, AsyncAPI::errorcode);
 
+//[callbacks_write_ec
 AsyncAPI::errorcode write_ec(AsyncAPI& api, const std::string& data)
 {
     boost::fibers::promise<AsyncAPI::errorcode> promise;
@@ -108,14 +113,18 @@ AsyncAPI::errorcode write_ec(AsyncAPI& api, const std::string& data)
         });
     return future.get();
 }
+//]
 
+//[callbacks_write
 void write(AsyncAPI& api, const std::string& data)
 {
     AsyncAPI::errorcode ec = write_ec(api, data);
     if (ec)
         throw make_exception("write", ec);
 }
+//]
 
+//[callbacks_read_ec
 std::pair<AsyncAPI::errorcode, std::string>
 read_ec(AsyncAPI& api)
 {
@@ -130,7 +139,9 @@ read_ec(AsyncAPI& api)
         });
     return future.get();
 }
+//]
 
+//[callbacks_read
 std::string read(AsyncAPI& api)
 {
     boost::fibers::promise<std::string> promise;
@@ -146,6 +157,7 @@ std::string read(AsyncAPI& api)
         });
     return future.get();
 }
+//]
 
 /*****************************************************************************
 *   helpers
@@ -193,7 +205,9 @@ int main(int argc, char *argv[])
     assert(thrown == make_exception("write", 2).what());
 
     // successful read_ec()
+//[callbacks_read_ec_call
     std::tie(ec, data) = read_ec(api);
+//]
     assert(! ec);
     assert(data == "efgh");         // last successful write_ec()
 

--- a/examples/adapt_method_calls.cpp
+++ b/examples/adapt_method_calls.cpp
@@ -22,6 +22,7 @@ struct AsyncAPIBase
     typedef int errorcode;
 };
 
+//[Response
 // every async operation receives a subclass instance of this abstract base
 // class through which to communicate its result
 struct Response
@@ -34,6 +35,7 @@ struct Response
     // called if the operation fails
     virtual void error(AsyncAPIBase::errorcode ec) = 0;
 };
+//]
 
 // the actual async API
 class AsyncAPI: public AsyncAPIBase
@@ -42,8 +44,10 @@ public:
     // constructor acquires some resource that can be read
     AsyncAPI(const std::string& data);
 
+//[method_init_read
     // derive Response subclass, instantiate, pass Response::ptr
     void init_read(Response::ptr);
+//]
 
     // ... other operations ...
     void inject_error(errorcode ec);
@@ -98,6 +102,7 @@ void AsyncAPI::init_read(Response::ptr response)
 // helper function
 std::runtime_error make_exception(const std::string& desc, AsyncAPI::errorcode);
 
+//[PromiseResponse
 class PromiseResponse: public Response
 {
 public:
@@ -121,7 +126,9 @@ public:
 private:
     boost::fibers::promise<std::string> promise_;
 };
+//]
 
+//[method_read
 std::string read(AsyncAPI& api)
 {
     // Because init_read() requires a shared_ptr, we must allocate our
@@ -133,6 +140,7 @@ std::string read(AsyncAPI& api)
     api.init_read(promisep);
     return future.get();
 }
+//]
 
 /*****************************************************************************
 *   helpers

--- a/examples/asio/detail/promise_handler.hpp
+++ b/examples/asio/detail/promise_handler.hpp
@@ -30,6 +30,7 @@ namespace asio {
 namespace detail {
 
 // Completion handler to adapt a promise as a completion handler.
+//[fibers_asio_promise_handler_base
 template< typename T >
 class promise_handler_base
 {
@@ -39,8 +40,10 @@ public:
     // Construct from any promise_completion_token subclass special value.
     template< typename Allocator >
     promise_handler_base( const boost::fibers::asio::promise_completion_token< Allocator >& pct) :
-        promise_( new boost::fibers::promise< T >( std::allocator_arg, pct.get_allocator() ) ),
-        ecp_( pct.ec_)
+        promise_( new boost::fibers::promise< T >( std::allocator_arg, pct.get_allocator() ) )
+//<-
+        , ecp_( pct.ec_)
+//->
     {}
 
     bool should_set_value( boost::system::error_code const& ec)
@@ -51,6 +54,7 @@ public:
             return true;
         }
 
+//<-
         // ec indicates error
         if (ecp_)
         {
@@ -63,7 +67,7 @@ public:
             // anyway.
             return true;
         }
-
+//->
         // no bound error_code: cause promise_ to throw an exception
         promise_->set_exception(
             std::make_exception_ptr(
@@ -77,15 +81,21 @@ public:
 
 private:
     promise_ptr                 promise_;
+//<-
     boost::system::error_code * ecp_;
+//->
 };
+//]
 
 // generic promise_handler for arbitrary value
+//[fibers_asio_promise_handler
 template< typename T >
 class promise_handler: public promise_handler_base<T>
 {
+//<-
     using promise_handler_base<T>::should_set_value;
 
+//->
 public:
     // Construct from any promise_completion_token subclass special value.
     template< typename Allocator >
@@ -93,19 +103,22 @@ public:
         promise_handler_base<T>( pct)
     {}
 
+//<-
     void operator()( T t)
     {
         get_promise()->set_value( t);
     }
-
+//->
     void operator()( boost::system::error_code const& ec, T t)
     {
         if (should_set_value(ec))
             get_promise()->set_value( t);
     }
-
+//<-
     using promise_handler_base<T>::get_promise;
+//->
 };
+//]
 
 // specialize promise_handler for void
 template<>

--- a/examples/asio/detail/yield.hpp
+++ b/examples/asio/detail/yield.hpp
@@ -31,8 +31,10 @@ namespace detail {
 
 // yield_handler is just an alias for promise_handler -- but we must
 // distinguish this case to specialize async_result below.
+//[fibers_asio_yield_handler
 template < typename T >
 using yield_handler = promise_handler<T>;
+//]
 
 } // detail
 } // asio
@@ -94,12 +96,14 @@ struct handler_type<
 // single-argument yield_handler: an error_code indicating error will be
 // conveyed to consumer code via an exception. Normal return implies (!
 // error_code).
+//[asio_handler_type
 template< typename Allocator, typename ReturnType, typename Arg2 >
 struct handler_type<
     boost::fibers::asio::yield_t< Allocator>,
     ReturnType( boost::system::error_code, Arg2)
 >
 { typedef fibers::asio::detail::yield_handler< Arg2 >    type; };
+//]
 
 } // namespace asio
 } // namespace boost

--- a/examples/asio/promise_completion_token.hpp
+++ b/examples/asio/promise_completion_token.hpp
@@ -48,6 +48,7 @@ namespace asio {
  * allocator.</dd>
  * </dl>
  */
+//[fibers_asio_promise_completion_token
 template< typename Allocator >
 class promise_completion_token
 {
@@ -76,6 +77,7 @@ public:
 private:
     Allocator allocator_;
 };
+//]
 
 } // namespace asio
 } // namespace fibers

--- a/examples/asio/yield.hpp
+++ b/examples/asio/yield.hpp
@@ -78,6 +78,7 @@ namespace asio {
  * boost::fibers::asio::yield.with(alloc_instance)[ec]
  * @endcode
  */
+//[fibers_asio_yield_t
 template< typename Allocator = std::allocator< void > >
 class yield_t: public promise_completion_token<Allocator>
 {
@@ -85,6 +86,9 @@ public:
     /// Construct with default-constructed allocator.
     BOOST_CONSTEXPR yield_t()
     {}
+/*=    // ... ways to use an alternate allocator or bind an error_code ...*/
+/*=};*/
+//]
 
     /// Construct using specified allocator.
     explicit yield_t( Allocator const& allocator) :
@@ -109,8 +113,10 @@ public:
     }
 };
 
+//[fibers_asio_yield
 /// A special value, similar to std::nothrow.
 BOOST_CONSTEXPR_OR_CONST yield_t<> yield;
+//]
 
 }}}
 


### PR DESCRIPTION
This covers both generic callbacks (adapt_callbacks.cpp,
adapt_method_calls.cpp) and custom Asio completion tokens (yield.hpp,
promise_completion_token.hpp, detail/yield.hpp, detail/promise_handler.hpp).
Mark up the relevant source files to provide code snippets for callbacks.qbk.