### PR TITLE
Correct mistaken advice about properties for newly-launched fiber.

### DIFF
--- a/doc/customization.qbk
+++ b/doc/customization.qbk
@@ -100,7 +100,7 @@ instance by calling [ns_function_link this_fiber..properties]. Although
 `properties<>()` is a nullary function, you must pass, as a template
 parameter, the `fiber_properties` subclass.
 
-[init]
+[main_name]
 
 Given a [class_link fiber] instance still connected with a running fiber (that
 is, not [member_link fiber..detach]ed), you may access that fiber's properties
@@ -108,17 +108,14 @@ using [template_member_link fiber..properties]. As with
 `this_fiber::properties<>()`, you must pass your `fiber_properties` subclass
 as the template parameter.
 
-[change_fn]
+[launch]
 
-Since launching a new fiber schedules that fiber right away, code such as the
-following:
-
-    boost::fibers::fiber newfiber( fiber_function);
-    newfiber.properties< priority_props >().name = "newfiber";
-
-will not necessarily set the property as soon as you expect. It is generally
-preferable to pass the initial property values to your `fiber_function()` and
-have it set them itself. In the example above, `change_fn()` accepts its own
-`name` and `priority` and calls `init()` to set the corresponding properties.
+Launching a new fiber schedules that fiber as ready, but does ['not]
+immediately enter its ['fiber-function]. The current fiber retains control
+until it blocks (or yields, or terminates) for some other reason. As shown in
+the `launch()` function above, it is reasonable to launch a fiber and
+immediately set relevant properties -- such as, for instance, its priority.
+Your custom scheduler can then make use of this information next time the
+fiber manager calls [member_link sched_algorithm_with_properties..pick_next].
 
 [endsect]

--- a/doc/fiber.qbk
+++ b/doc/fiber.qbk
@@ -148,10 +148,9 @@ the joined __fiber__ object becomes __not_a_fiber__.
 
 [heading Destruction]
 
-When a __fiber__ object representing a valid execution context is destroyed, the
-program terminates if the fiber is __joinable__. If you intend the
-fiber to outlive the __fiber__ object that launched it, use the __detach__
-method.
+When a __fiber__ object representing a valid execution context (the fiber is
+__joinable__) is destroyed, the program terminates. If you intend the fiber to
+outlive the __fiber__ object that launched it, use the __detach__ method.
 
         {
             boost::fibers::fiber f( some_fn);
@@ -329,7 +328,7 @@ operators on __fiber_id__ yield a total order for every non-equal __fiber_id__.
 [[Note:] [StackAllocator is required to allocate a stack for the internal
 __econtext__. If StackAllocator is not explicitly passed, a
 __fixedsize_stack__ is used by default.]]
-[[See also:] [[link stack]]]
+[[See also:] [[link stack Stack allocation]]]
 ]
 
 [heading Move constructor]
@@ -387,10 +386,9 @@ may not have completed; otherwise `false`.]]
 
 [variablelist
 [[Preconditions:] [the fiber is __joinable__.]]
-[[Effects:] [If `*this` refers to a fiber of execution, waits for that fiber to
-complete.]]
-[[Postconditions:] [If `*this` refers to a fiber of execution on entry, that
-fiber has completed. `*this` no longer refers to any fiber of execution.]]
+[[Effects:] [Waits for the referenced fiber of execution to complete.]]
+[[Postconditions:] [The fiber of execution referenced on entry has completed.
+`*this` no longer refers to any fiber of execution.]]
 [[Throws:] [__fiber_interrupted__ if the current fiber is interrupted or
 `system_error`]]
 [[Error Conditions:] [

--- a/doc/fiber.qbk
+++ b/doc/fiber.qbk
@@ -447,15 +447,14 @@ interruption enabled.]]
 [[Preconditions:] [`*this` refers to a fiber of execution. [function_link
 use_scheduling_algorithm] has been called from this thread with a subclass of
 [template_link sched_algorithm_with_properties] with the same template
-argument `PROPS`. `*this` has been scheduled for execution at least once.]]
+argument `PROPS`.]]
 [[Returns:] [a reference to the scheduler properties instance for `*this`.]]
 [[Throws:] [`std::bad_cast` if `use_scheduling_algorithm()` was called with a
 `sched_algorithm_with_properties` subclass with some other template parameter
 than `PROPS`.]]
 [[Note:] [[template_link sched_algorithm_with_properties] provides a way for a
 user-coded scheduler to associate extended properties, such as priority, with
-a fiber instance. This method allows access to those user-provided properties
-[mdash] but only after this fiber has been scheduled for the first time.]]
+a fiber instance. This method allows access to those user-provided properties.]]
 [[See also:] [[link custom Customization]]]
 ]
 

--- a/examples/priority.cpp
+++ b/examples/priority.cpp
@@ -213,7 +213,7 @@ public:
 };
 //]
 
-//[init
+//[launch
 template < typename Fn >
 boost::fibers::fiber launch( Fn && func, std::string const& name, int priority) {
     boost::fibers::fiber fiber(func);
@@ -270,18 +270,20 @@ void change_fn( boost::fibers::fiber & other,
 
 //[main
 int main( int argc, char *argv[]) {
-    Verbose v("main()");
     // make sure we use our priority_scheduler rather than default round_robin
     boost::fibers::use_scheduling_algorithm< priority_scheduler >();
 /*=    ...*/
 /*=}*/
 //]
+    Verbose v("main()");
 
     // for clarity
     std::cout << "main() yielding" << std::endl;
     boost::this_fiber::yield();
     std::cout << "main() setting name" << std::endl;
+//[main_name
     boost::this_fiber::properties<priority_props>().name = "main";
+//]
     std::cout << "main() running tests" << std::endl;
 
     {

--- a/examples/priority.cpp
+++ b/examples/priority.cpp
@@ -278,8 +278,6 @@ int main( int argc, char *argv[]) {
     Verbose v("main()");
 
     // for clarity
-    std::cout << "main() yielding" << std::endl;
-    boost::this_fiber::yield();
     std::cout << "main() setting name" << std::endl;
 //[main_name
     boost::this_fiber::properties<priority_props>().name = "main";


### PR DESCRIPTION
I changed my advice about setting properties.

I also changed `examples/priority.cpp` to reflect my new understanding, converting the `init()` function to a `launch()` function that launches the fiber and immediately sets its properties.

Scrutinizing `priority.cpp` output, I discovered a bug in my `priority_scheduler::property_change()` method. Given a ready queue containing [medium(2), low(1), high(0)], a `property_change()` call with `high` reset to priority 3 would move it here: [medium(2), high(3), low(1)].

That rubbed my nose in the fact that my "clever" single-pass `property_change()` logic was hard to reason about -- bad news for an example program! I decided to convert it to two simpler passes: the first to find and unlink the passed fiber_context\*, the second to re-insert it in the correct place. Happily, I then realized that once the fiber_context\* is unlinked, I already *have* a method to reinsert it in the correct place: `awakened()`. Empirically, observing the output, this works -- and is much easier to desk-check.

I'm somewhat curious whether you would consider my original "clever" single-pass logic to be an example of premature optimization. That is, without actually running a profiler, does intuition have anything useful to suggest about the relative performance of a single pass through a linked list, with conditionals, versus two simpler passes?

While paying attention to `priority.cpp` output, I decided to set the name of the main fiber too -- which surfaced another bug, this time in `this_fiber::properties<>()`. The mechanism relies on `sched_algorithm_with_properties::awakened()` to instantiate the `fiber_properties` subclass for each `fiber_context*`. But each thread's main fiber is entered without having passed through the scheduler! Fortunately there's a simple workaround: all you have to do is call `this_fiber::yield()` to detour through the scheduler. I made `this_fiber::properties<>()` invoke that workaround as needed.

This *could* have unforeseen side effects if your main fiber instantiates some number of `fiber` objects before deciding to set its own properties: the new fibers will run before you perhaps expect them to. I consider that an obscure and unlikely problem. I think if you plan to set the main fiber's properties, you'll probably do it early. The bit about detouring through the scheduler, the requirement to pass through `sched_algorithm_with_properties::awakened()`, is an implementation detail I don't particularly want to have to explain.

What do you think?
