### PR TITLE
Fixes namespace scope closed twice.

### DIFF
--- a/include/boost/fiber/future/future.hpp
+++ b/include/boost/fiber/future/future.hpp
@@ -93,8 +93,6 @@ struct future_base {
     }
 };
 
-}
-
 template< typename R >
 struct promise_base;
 


### PR DESCRIPTION
MSVC was failing to resolve some types in [fiber/future/future.hpp](https://github.com/olk/boost-fiber/blob/3a75f00f10261f1be160621fca7223849ff945e4/include/boost/fiber/future/future.hpp#L96). It looks like the boost::fibers::detail scope is beeing closed twice. The offending brace seems to be at [line 96](https://github.com/olk/boost-fiber/blob/3a75f00f10261f1be160621fca7223849ff945e4/include/boost/fiber/future/future.hpp#L96)