### PR TITLE
Introduce thread_sched_algorithm with standard suspend_until(), notif…

### DIFF
--- a/examples/asio/ps/server.cpp
+++ b/examples/asio/ps/server.cpp
@@ -15,6 +15,7 @@
 #include <set>
 #include <iostream>
 #include <string>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>

--- a/examples/asio/round_robin.hpp
+++ b/examples/asio/round_robin.hpp
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/asio.hpp>
 #include <boost/assert.hpp>

--- a/examples/priority.cpp
+++ b/examples/priority.cpp
@@ -71,8 +71,8 @@ private:
 
 //[priority_scheduler
 class priority_scheduler :
-    public boost::fibers::thread_sched_algorithm,  // suspend_until(), notify()
-    public boost::fibers::sched_algorithm_with_properties< priority_props > {
+    virtual public boost::fibers::thread_sched_algorithm,  // suspend_until(), notify()
+    virtual public boost::fibers::sched_algorithm_with_properties< priority_props > {
 private:
     typedef boost::fibers::scheduler::ready_queue_t/*< See [link ready_queue_t]. >*/   rqueue_t;
 

--- a/examples/priority.cpp
+++ b/examples/priority.cpp
@@ -4,9 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <chrono>
-#include <condition_variable>
 #include <iostream>
-#include <mutex>
 #include <algorithm>                // std::find_if()
 
 #include <boost/fiber/all.hpp>

--- a/examples/wait_stuff.cpp
+++ b/examples/wait_stuff.cpp
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/fiber/all.hpp>
 #include <boost/noncopyable.hpp>

--- a/examples/work_sharing.cpp
+++ b/examples/work_sharing.cpp
@@ -4,7 +4,6 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <chrono>
-#include <condition_variable>
 #include <cstddef>
 #include <iomanip>
 #include <iostream>

--- a/examples/work_stealing.cpp
+++ b/examples/work_stealing.cpp
@@ -88,14 +88,11 @@ public:
     }
 };
 
-class victim_algo : public boost::fibers::sched_algorithm {
+class victim_algo : public boost::fibers::thread_sched_algorithm {
 private:
     typedef work_stealing_queue        rqueue_t;
 
     std::shared_ptr< rqueue_t > rqueue_{};
-    std::mutex                  mtx_{};
-    std::condition_variable     cnd_{};
-    bool                        flag_{ false };
 
 public:
     victim_algo( std::shared_ptr< rqueue_t > rqueue) :
@@ -114,28 +111,9 @@ public:
     virtual bool has_ready_fibers() const noexcept {
         return ! rqueue_->empty();
     }
-
-    void suspend_until( std::chrono::steady_clock::time_point const& time_point) noexcept {
-        if ( (std::chrono::steady_clock::time_point::max)() == time_point) {
-            std::unique_lock< std::mutex > lk( mtx_);
-            cnd_.wait( lk, [this](){ return flag_; });
-            flag_ = false;
-        } else {
-            std::unique_lock< std::mutex > lk( mtx_);
-            cnd_.wait_until( lk, time_point, [this](){ return flag_; });
-            flag_ = false;
-        }
-    }
-
-    void notify() noexcept {
-        std::unique_lock< std::mutex > lk( mtx_);
-        flag_ = true;
-        lk.unlock();
-        cnd_.notify_all();
-    }
 };
 
-class tief_algo : public boost::fibers::sched_algorithm {
+class tief_algo : public boost::fibers::thread_sched_algorithm {
 private:
     typedef boost::fibers::scheduler::ready_queue_t rqueue_t;
     typedef work_stealing_queue                     ws_rqueue_t;
@@ -143,9 +121,6 @@ private:
     rqueue_t                        rqueue_{};
     std::shared_ptr< ws_rqueue_t >  ws_rqueue_;
     std::atomic< int >           *  count_;
-    std::mutex                      mtx_{};
-    std::condition_variable         cnd_{};
-    bool                            flag_{ false };
 
 public:
     tief_algo( std::shared_ptr< ws_rqueue_t > ws_rqueue, std::atomic< int > * count) :
@@ -179,25 +154,6 @@ public:
 
     virtual bool has_ready_fibers() const noexcept {
         return ! rqueue_.empty();
-    }
-
-    void suspend_until( std::chrono::steady_clock::time_point const& time_point) noexcept {
-        if ( (std::chrono::steady_clock::time_point::max)() == time_point) {
-            std::unique_lock< std::mutex > lk( mtx_);
-            cnd_.wait( lk, [this](){ return flag_; });
-            flag_ = false;
-        } else {
-            std::unique_lock< std::mutex > lk( mtx_);
-            cnd_.wait_until( lk, time_point, [this](){ return flag_; });
-            flag_ = false;
-        }
-    }
-
-    void notify() noexcept {
-        std::unique_lock< std::mutex > lk( mtx_);
-        flag_ = true;
-        lk.unlock();
-        cnd_.notify_all();
     }
 };
 

--- a/examples/work_stealing.cpp
+++ b/examples/work_stealing.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <cstdio>
 #include <iomanip>
 #include <iostream>

--- a/include/boost/fiber/algorithm.hpp
+++ b/include/boost/fiber/algorithm.hpp
@@ -8,6 +8,8 @@
 
 #include <cstddef>
 #include <chrono>
+#include <mutex>
+#include <condition_variable>
 
 #include <boost/config.hpp>
 #include <boost/assert.hpp>

--- a/include/boost/fiber/algorithm.hpp
+++ b/include/boost/fiber/algorithm.hpp
@@ -46,7 +46,7 @@ struct BOOST_FIBERS_DECL sched_algorithm {
 // the scheduler is idle. thread_sched_algorithm provides suspend_until() and
 // notify() implementations, allowing its subclasses to focus on awakened(),
 // pick_next() and has_ready_fibers().
-class BOOST_FIBERS_DECL thread_sched_algorithm : public sched_algorithm {
+class BOOST_FIBERS_DECL thread_sched_algorithm : virtual public sched_algorithm {
 private:
     std::mutex                  mtx_{};
     std::condition_variable     cnd_{};
@@ -60,7 +60,7 @@ public:
 
 // This sched_algorithm subclass provides common functionality for every
 // sched_algorithm_with_properties<> specialization.
-class BOOST_FIBERS_DECL sched_algorithm_with_properties_base : public sched_algorithm {
+class BOOST_FIBERS_DECL sched_algorithm_with_properties_base : virtual public sched_algorithm {
 public:
     // called by fiber_properties::notify() -- don't directly call
     virtual void property_change_( context * f, fiber_properties * props) noexcept = 0;
@@ -73,7 +73,7 @@ protected:
 // This sched_algorithm subclass helps manage instances of a specified
 // fiber-specific properties class, which must be derived from fiber_properties.
 template< typename PROPS >
-struct sched_algorithm_with_properties : public sched_algorithm_with_properties_base {
+struct sched_algorithm_with_properties : virtual public sched_algorithm_with_properties_base {
     typedef sched_algorithm_with_properties_base super;
 
     // Mark this override 'final': sched_algorithm_with_properties subclasses

--- a/include/boost/fiber/bounded_channel.hpp
+++ b/include/boost/fiber/bounded_channel.hpp
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
-#include <mutex>
+#include <mutex>                    // std::unique_lock
 #include <system_error>
 #include <utility>
 

--- a/include/boost/fiber/condition_variable.hpp
+++ b/include/boost/fiber/condition_variable.hpp
@@ -10,9 +10,8 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <functional>
-#include <mutex>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>

--- a/include/boost/fiber/detail/spinlock.hpp
+++ b/include/boost/fiber/detail/spinlock.hpp
@@ -10,7 +10,7 @@
 #define BOOST_FIBERS_SPINLOCK_H
 
 #include <atomic>
-#include <mutex>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/fiber/detail/config.hpp>
 

--- a/include/boost/fiber/future/detail/shared_state.hpp
+++ b/include/boost/fiber/future/detail/shared_state.hpp
@@ -13,7 +13,7 @@
 #include <cstddef>
 #include <exception>
 #include <memory>
-#include <mutex>
+#include <mutex>                    // std::unique_lock
 #include <type_traits>
 
 #include <boost/assert.hpp>

--- a/include/boost/fiber/round_robin.hpp
+++ b/include/boost/fiber/round_robin.hpp
@@ -6,9 +6,7 @@
 #ifndef BOOST_FIBERS_DEFAULT_ROUND_ROBIN_H
 #define BOOST_FIBERS_DEFAULT_ROUND_ROBIN_H
 
-#include <condition_variable>
 #include <chrono>
-#include <mutex>
 
 #include <boost/config.hpp>
 

--- a/include/boost/fiber/round_robin.hpp
+++ b/include/boost/fiber/round_robin.hpp
@@ -26,12 +26,9 @@ namespace fibers {
 
 class context;
 
-class BOOST_FIBERS_DECL round_robin : public sched_algorithm {
+class BOOST_FIBERS_DECL round_robin : public thread_sched_algorithm {
 private:
     scheduler::ready_queue_t    ready_queue_{};
-    std::mutex                  mtx_{};
-    std::condition_variable     cnd_{};
-    bool                        flag_{ false };
 
 public:
     round_robin() = default;
@@ -44,10 +41,6 @@ public:
     virtual context * pick_next() noexcept;
 
     virtual bool has_ready_fibers() const noexcept;
-
-    virtual void suspend_until( std::chrono::steady_clock::time_point const&) noexcept;
-
-    virtual void notify() noexcept;
 };
 
 }}

--- a/include/boost/fiber/scheduler.hpp
+++ b/include/boost/fiber/scheduler.hpp
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <functional>
 #include <memory>
-#include <mutex>
 
 #include <boost/config.hpp>
 #include <boost/context/execution_context.hpp>

--- a/include/boost/fiber/unbounded_channel.hpp
+++ b/include/boost/fiber/unbounded_channel.hpp
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
-#include <mutex>
+#include <mutex>                    // std::unique_lock
 #include <utility>
 
 #include <boost/config.hpp>

--- a/src/algorithm.cpp
+++ b/src/algorithm.cpp
@@ -15,6 +15,30 @@
 namespace boost {
 namespace fibers {
 
+void
+thread_sched_algorithm::suspend_until( std::chrono::steady_clock::time_point const& time_point) noexcept {
+    if ( (std::chrono::steady_clock::time_point::max)() == time_point) {
+        // Some implementations of std::condition_variable::wait_until() don't
+        // deal well with time_point == time_point::max(), so detect that case
+        // and call vanilla wait() instead, with no timeout.
+        std::unique_lock< std::mutex > lk( mtx_);
+        cnd_.wait( lk, [&](){ return flag_; });
+        flag_ = false;
+    } else {
+        std::unique_lock< std::mutex > lk( mtx_);
+        cnd_.wait_until( lk, time_point, [&](){ return flag_; });
+        flag_ = false;
+    }
+}
+
+void
+thread_sched_algorithm::notify() noexcept {
+    std::unique_lock< std::mutex > lk( mtx_);
+    flag_ = true;
+    lk.unlock();
+    cnd_.notify_all();
+}
+
 //static
 fiber_properties *
 sched_algorithm_with_properties_base::get_properties( context * ctx) noexcept {

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -7,6 +7,7 @@
 #include "boost/fiber/barrier.hpp"
 
 #include <system_error>
+#include <mutex>                    // std::unique_lock
 
 #include "boost/fiber/exceptions.hpp"
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 #include <new>
+#include <mutex>                    // std::unique_lock
 
 #include "boost/fiber/exceptions.hpp"
 #include "boost/fiber/interruption.hpp"

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -28,7 +28,7 @@ fiber_properties::notify() noexcept {
     // with a change to a fiber it's not currently tracking: it will do the
     // right thing next time the fiber is passed to its awakened() method.
     if ( ctx_->ready_is_linked() ) {
-        static_cast< sched_algorithm_with_properties_base * >( sched_algo_)->
+        dynamic_cast< sched_algorithm_with_properties_base * >( sched_algo_)->
             property_change_( ctx_, this);
     }
 }

--- a/src/round_robin.cpp
+++ b/src/round_robin.cpp
@@ -40,27 +40,6 @@ round_robin::has_ready_fibers() const noexcept {
     return ! ready_queue_.empty();
 }
 
-void
-round_robin::suspend_until( std::chrono::steady_clock::time_point const& time_point) noexcept {
-    if ( (std::chrono::steady_clock::time_point::max)() == time_point) {
-        std::unique_lock< std::mutex > lk( mtx_);
-        cnd_.wait( lk, [&](){ return flag_; });
-        flag_ = false;
-    } else {
-        std::unique_lock< std::mutex > lk( mtx_);
-        cnd_.wait_until( lk, time_point, [&](){ return flag_; });
-        flag_ = false;
-    }
-}
-
-void
-round_robin::notify() noexcept {
-    std::unique_lock< std::mutex > lk( mtx_);
-    flag_ = true;
-    lk.unlock();
-    cnd_.notify_all();
-}
-
 }}
 
 #ifdef BOOST_HAS_ABI_HEADERS

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -7,7 +7,7 @@
 #include "boost/fiber/scheduler.hpp"
 
 #include <chrono>
-#include <mutex>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/assert.hpp>
 

--- a/test/test_condition_mt.cpp
+++ b/test/test_condition_mt.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <stdexcept>
 #include <vector>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/atomic.hpp>
 #include <boost/bind.hpp>

--- a/test/test_condition_variable.cpp
+++ b/test/test_condition_variable.cpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <stdexcept>
 #include <vector>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/test_fiber.cpp
+++ b/test/test_fiber.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <sstream>
 #include <string>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/assert.hpp>
 #include <boost/test/unit_test.hpp>

--- a/test/test_fss.cpp
+++ b/test/test_fss.cpp
@@ -6,6 +6,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <iostream>
+#include <mutex>                    // std::unique_lock
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/test_mutex.cpp
+++ b/test/test_mutex.cpp
@@ -10,7 +10,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <map>
-#include <mutex>
+#include <mutex>                    // std::unique_lock
 #include <stdexcept>
 #include <vector>
 


### PR DESCRIPTION
…y().

round_robin, along with pretty much every example program's scheduler except
examples/asio/round_robin.hpp, uses the same suspend_until() / notify()
implementation. It's not a stretch to assume that most Fiber applications that
customize sched_algorithm at all will use the very same implementations as
well. Instead of forcing them to copy/paste from round_robin, allow them to
derive from thread_sched_algorithm.